### PR TITLE
connection.py: do not send messages when mail.suppress is set

### DIFF
--- a/flask_sendmail/connection.py
+++ b/flask_sendmail/connection.py
@@ -18,6 +18,9 @@ class Connection(object):
         pass
 
     def send(self, message):
+        if self.suppress:
+            return 0
+
         sm = Popen([self.mail.mailer, self.mail.mailer_flags], stdin=PIPE,
                    stdout=PIPE, stderr=STDOUT)
         sm.stdin.write(message.dump())


### PR DESCRIPTION
It seems to me that neither `app.testing` from Flask nor the `MAIL_SUPPRESS_SEND` configuration variable are ever enforced, even through the `Mail.suppress` class member. This patch should actually implement the behaviour expected as documented, actually preventing sending e-mails when they should not be sent.