### PR TITLE
connection.py: send messages as binary data through stdio

### DIFF
--- a/flask_sendmail/connection.py
+++ b/flask_sendmail/connection.py
@@ -20,7 +20,7 @@ class Connection(object):
     def send(self, message):
         sm = Popen([self.mail.mailer, self.mail.mailer_flags], stdin=PIPE,
                    stdout=PIPE, stderr=STDOUT)
-        sm.stdin.write(message.dump())
+        sm.stdin.write(message.dump().encode())
         sm.communicate()
 
         return sm.returncode


### PR DESCRIPTION
This fixes sending e-mails with Flask-Sendmail when using Python 3.8.